### PR TITLE
Changing ansible-lint to hardcoded version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 *.swo
 *.swp
 *.retry
+
+tests/Dockerfile

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,14 +5,14 @@ env:
     init: /sbin/init
     run_opts: ""
   - distro: ubuntu1604
-    init: /sbin/init
+    init: /lib/systemd/systemd
     run_opts: ""
   - distro: fedora24
     init: /usr/lib/systemd/systemd
     run_opts: "--privileged --volume=/sys/fs/cgroup:/sys/fs/cgroup:ro"
   - distro: centos6
     init: /sbin/init
-    run_opts: "--privileged --volume=/sys/fs/cgroup:/sys/fs/cgroup:ro"
+    run_opts: ""
   - distro: centos7
     init: /usr/lib/systemd/systemd
     run_opts: "--privileged --volume=/sys/fs/cgroup:/sys/fs/cgroup:ro"
@@ -22,9 +22,7 @@ services:
 
 install:
   - pip install ansible==2.1.1.0
-
-  # Check ansible version
-  - ansible --version
+  - pip install ansible-lint==3.3.3
 
 script:
   - ./build

--- a/build
+++ b/build
@@ -3,14 +3,12 @@
 # Exit immediately on error
 set -e
 
-# Pull container.
-sudo docker pull geerlingguy/docker-${distro}-ansible:latest
+echo "FROM geerlingguy/docker-${distro}-ansible:latest" > tests/Dockerfile
 
 # Customize container
 container_tag=${distro}:ansible
 sudo docker build \
   --rm=true \
-  --file=tests/Dockerfile.${distro} \
   --tag=${container_tag} tests
 
 # Run container in detached state
@@ -29,14 +27,17 @@ sudo docker exec "${container_id}" \
   ansible-playbook /etc/ansible/roles/role_under_test/tests/install.yml \
     --syntax-check
 
-# Ansible lint check.
-sudo docker exec "${container_id}" \
-  env TERM=xterm \
-  ansible-lint /etc/ansible/roles/role_under_test/tests/install.yml
-
 # Check that role installs successfully.
 install_dir=/opt
 sudo docker exec "${container_id}" \
   env TERM=xterm \
   ansible-playbook /etc/ansible/roles/role_under_test/tests/install.yml \
     --extra-vars "web100clt_install_dir=${install_dir}"
+
+# Clean up
+sudo docker stop "${container_id}"
+sudo docker rm "${container_id}"
+rm tests/Dockerfile
+
+# Ansible lint check (outside of docker container).
+ansible-lint tests/install.yml

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -45,7 +45,6 @@
     repo: https://github.com/ndt-project/ndt.git
     dest: "{{ web100clt_install_dir }}/ndt"
     version: "{{ web100clt_ndt_version }}"
-    force: yes
   register: ndt_source
 
 - name: build and install I2util from source

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -3,6 +3,7 @@
   apt:
     name: "{{ item }}"
     state: installed
+    update_cache: yes
   with_items:
     - automake
     - gcc

--- a/tests/Dockerfile.centos6
+++ b/tests/Dockerfile.centos6
@@ -1,6 +1,0 @@
-FROM geerlingguy/docker-centos6-ansible:latest
-
-# Install ansible-lint
-RUN yum update -y
-RUN yum install -y gcc python-devel gmp-devel python-setuptools
-RUN easy_install Jinja2 ansible-lint

--- a/tests/Dockerfile.centos7
+++ b/tests/Dockerfile.centos7
@@ -1,6 +1,0 @@
-FROM geerlingguy/docker-centos7-ansible:latest
-
-# Install ansible-lint
-RUN yum update -y
-RUN yum install -y python-pip
-RUN pip install ansible-lint

--- a/tests/Dockerfile.fedora24
+++ b/tests/Dockerfile.fedora24
@@ -1,6 +1,0 @@
-FROM geerlingguy/docker-fedora24-ansible:latest
-
-# Install ansible-lint
-RUN yum update -y
-RUN yum install -y python-pip
-RUN pip install ansible-lint

--- a/tests/Dockerfile.ubuntu1404
+++ b/tests/Dockerfile.ubuntu1404
@@ -1,6 +1,0 @@
-FROM geerlingguy/docker-ubuntu1404-ansible:latest
-
-# Install ansible-lint
-RUN apt-get update
-RUN apt-get install -y python-pip
-RUN pip install ansible-lint

--- a/tests/Dockerfile.ubuntu1604
+++ b/tests/Dockerfile.ubuntu1604
@@ -1,6 +1,0 @@
-FROM geerlingguy/docker-ubuntu1604-ansible:latest
-
-# Install ansible-lint
-RUN apt-get update
-RUN apt-get install -y python-pip
-RUN pip install ansible-lint


### PR DESCRIPTION
Changing the ansible-lint setup so that it's a fixed version rather than
whatever version happens to be latest. Also fixes environment variables for
some distros.